### PR TITLE
Configuración en el pom del jbcrypt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,5 +22,10 @@
             <artifactId>hibernate-core</artifactId>
             <version>5.4.30.Final</version>
         </dependency>
+        <dependency>
+            <groupId>org.mindrot</groupId>
+            <artifactId>jbcrypt</artifactId>
+            <version>0.4</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Configuración de la dependencia jbcrypt para encriptar con hash el nip de la tarjeta.